### PR TITLE
get rid of environment variable

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    testing: { // matches the `NODE_ENV=testing` in "test" script in package.json
+    test: {
       plugins: [
         '@babel/plugin-transform-runtime',
       ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "NODE_ENV=testing jest --watchAll --verbose --forceExit --silent"
+    "test": "jest --watchAll --verbose --forceExit --silent"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Forgot to use "cross-env" to ensure injecting the NODE_ENV works in Windows. Have decided to simply get rid of the environment variable altogether.